### PR TITLE
update-resume-subgraph-fix

### DIFF
--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -1,0 +1,1 @@
+2.0.1: expose on_failure subgraphs inside the module since Cloudify workflows calls get_func.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2,7 +2,7 @@ plugins:
   cloudify_smart_update:
     executor: central_deployment_agent
     package_name: cloudify-smartupdate-plugin
-    package_version: '2.0'
+    package_version: '2.0.1'
 
 
 workflows:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Do not use underscores in the plugin name.
     name='cloudify-smartupdate-plugin',
 
-    version='2.0',
+    version='2.0.1',
     author='Cloudify',
     author_email='cosmo-admin@cloudify.co',
     description='''


### PR DESCRIPTION
expose on_failure handlers method , due to error on resume update 
```2022-01-13 09:22:52,499:INFO: [2c0c66c9-38bc-4bd5-a910-b37207e0f235] 'update' workflow execution failed: plugin.lifecycle has no function named 'subgraph_on_failure_handler'
2022-01-13 09:22:52,866:ERROR: Task plugin.workflows.smart_update[2c0c66c9-38bc-4bd5-a910-b37207e0f235] raised:
Traceback (most recent call last):
  File "/opt/mgmtworker/env/lib/python3.6/site-packages/cloudify/utils.py", line 406, in get_func
    func = getattr(module, function_name)
AttributeError: module 'plugin.lifecycle' has no attribute 'subgraph_on_failure_handler'